### PR TITLE
Implemented Adopt Event, Hid Rehome Buttons, Fixed Icons

### DIFF
--- a/Assets/Prefabs/PickupPup/Shelter/DogAdoptProfile.prefab
+++ b/Assets/Prefabs/PickupPup/Shelter/DogAdoptProfile.prefab
@@ -1503,7 +1503,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 1
+  m_SortingOrder: 5
   m_TargetDisplay: 0
 --- !u!224 &224107461432160670
 RectTransform:
@@ -1521,8 +1521,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 134.5, y: -57.5}
-  m_SizeDelta: {x: 269, y: 57.5}
+  m_AnchoredPosition: {x: 80.5, y: -57.5}
+  m_SizeDelta: {x: 161, y: 57.5}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!224 &224109286519956918
 RectTransform:
@@ -1540,8 +1540,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 134.5, y: -120}
-  m_SizeDelta: {x: 269, y: 57.5}
+  m_AnchoredPosition: {x: 80.5, y: -120}
+  m_SizeDelta: {x: 161, y: 57.5}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!224 &224125529429893028
 RectTransform:
@@ -1618,8 +1618,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 134.5, y: 0}
-  m_SizeDelta: {x: 269, y: 100}
+  m_AnchoredPosition: {x: 80.5, y: 0}
+  m_SizeDelta: {x: 161, y: 100}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!224 &224241168554744662
 RectTransform:
@@ -1655,7 +1655,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224324728102931472
 RectTransform:
@@ -1674,8 +1674,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 134.5, y: -120}
-  m_SizeDelta: {x: 269, y: 120}
+  m_AnchoredPosition: {x: 80.5, y: -120}
+  m_SizeDelta: {x: 161, y: 120}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!224 &224368435502473550
 RectTransform:
@@ -1791,7 +1791,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224668412451646334
 RectTransform:
@@ -1847,8 +1847,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 82, y: -52.5}
-  m_SizeDelta: {x: 164, y: 47.5}
+  m_AnchoredPosition: {x: 28, y: -52.5}
+  m_SizeDelta: {x: 56, y: 47.5}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!224 &224825705984687810
 RectTransform:
@@ -1884,8 +1884,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 82, y: 0}
-  m_SizeDelta: {x: 164, y: 47.5}
+  m_AnchoredPosition: {x: 28, y: 0}
+  m_SizeDelta: {x: 56, y: 47.5}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!224 &224858564705525654
 RectTransform:

--- a/Assets/Scenes/Dev/AdoptionProfile_Dev.unity
+++ b/Assets/Scenes/Dev/AdoptionProfile_Dev.unity
@@ -1,0 +1,280 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 7
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 4
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_DirectLightInLightProbes: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+  m_LightingDataAsset: {fileID: 0}
+  m_RuntimeCPUUsage: 25
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    accuratePlacement: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &1533587282
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224472087411766220, guid: 5821fc2ba76109d49b6efd1b50689b5f,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5821fc2ba76109d49b6efd1b50689b5f, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1 &2136333720
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2136333725}
+  - component: {fileID: 2136333724}
+  - component: {fileID: 2136333723}
+  - component: {fileID: 2136333722}
+  - component: {fileID: 2136333721}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2136333721
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2136333720}
+  m_Enabled: 1
+--- !u!124 &2136333722
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2136333720}
+  m_Enabled: 1
+--- !u!92 &2136333723
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2136333720}
+  m_Enabled: 1
+--- !u!20 &2136333724
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2136333720}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &2136333725
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2136333720}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Dev/AdoptionProfile_Dev.unity.meta
+++ b/Assets/Scenes/Dev/AdoptionProfile_Dev.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f19e1fa5dfdd64d7390a23044c4b2372
+timeCreated: 1485706702
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/LivingRoom.unity
+++ b/Assets/Scenes/LivingRoom.unity
@@ -221,7 +221,7 @@ Prefab:
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -354.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
@@ -231,7 +231,7 @@ Prefab:
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 709
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224582402425969930, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
@@ -1078,7 +1078,7 @@ Prefab:
     - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1098,7 +1098,7 @@ Prefab:
     - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1108,7 +1108,7 @@ Prefab:
     - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1128,7 +1128,7 @@ Prefab:
     - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1138,7 +1138,7 @@ Prefab:
     - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1163,7 +1163,7 @@ Prefab:
     - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1183,7 +1183,7 @@ Prefab:
     - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1193,7 +1193,7 @@ Prefab:
     - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1213,7 +1213,7 @@ Prefab:
     - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1223,7 +1223,7 @@ Prefab:
     - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1248,7 +1248,7 @@ Prefab:
     - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1268,7 +1268,7 @@ Prefab:
     - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1278,7 +1278,7 @@ Prefab:
     - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1298,7 +1298,7 @@ Prefab:
     - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1308,7 +1308,7 @@ Prefab:
     - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1333,7 +1333,7 @@ Prefab:
     - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1353,7 +1353,7 @@ Prefab:
     - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1363,7 +1363,7 @@ Prefab:
     - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1383,7 +1383,7 @@ Prefab:
     - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1393,7 +1393,7 @@ Prefab:
     - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}


### PR DESCRIPTION
To explain some of the UI changes, the CloseProfileHitAreas should not play the MenuClick noise supported by UIButton. It needs to play the Back SFX, like the MainMenu and Settings prefabs do.

**Prefabs**
- DogBrowser: deactivated "RehomeFrame" GameObject, removed UIButton component on CloseProfileHitArea & set the button's OnClick() method to call its parent's Hide() method
- DogProfile, DogAdoptProfile: deactivated "Icons" GameObject, removed UIButton component on CloseProfileHitArea & set the button's OnClick() method to call its parent's Hide() method
- MainMenu: replaced Shop icon with the correct one

**Scripts**
- DogAdoptProfile: subscribed to the global adopt event, shows the Adopted display if the adoption is successful