### PR TITLE
Fixing duplicate dog in shelter

### DIFF
--- a/Assets/Scripts/Data/PickupPup/DogDatabase.cs
+++ b/Assets/Scripts/Data/PickupPup/DogDatabase.cs
@@ -165,6 +165,8 @@ public class DogDatabase : Database<DogDatabase>
 		buffer.Refresh();
         DogDescriptor[] fullSequence = buffer.GetRandom(dogs.Length);
 		DogDescriptor[] candidates = ArrayUtil.GetRange(fullSequence, startIndex, count);
+        // Allows for faster lookup versus O(n) to check array
+        HashSet<DogDescriptor> currentCandidates = new HashSet<DogDescriptor>(candidates);
         // -1 for zero offset
         int currentIndex = startIndex + count - 1;
         int totalDogCount = fullSequence.Length;
@@ -174,10 +176,18 @@ public class DogDatabase : Database<DogDatabase>
             {
                 if(!dataController.CheckAdopted(fullSequence[currentIndex]))
                 {
-                    candidates[i] = fullSequence[currentIndex];
+                    if(!currentCandidates.Contains(fullSequence[currentIndex]))
+                    {
+                        // Remove the old dog from the Hash (because it's invalid)
+                        currentCandidates.Remove(candidates[i]);
+                        candidates[i] = fullSequence[currentIndex];
+                        // Update the Hash w/ the new dog
+                        currentCandidates.Add(candidates[i]);
+                    }
                 }
                 currentIndex++;
             }
+            currentIndex++;
             if(currentIndex >= totalDogCount && dataController.CheckAdopted(candidates[i]))
             {
                 candidates[i] = DogDescriptor.Default();

--- a/Assets/Scripts/Data/PickupPup/DogDescriptor.cs
+++ b/Assets/Scripts/Data/PickupPup/DogDescriptor.cs
@@ -261,4 +261,16 @@ public class DogDescriptor : PPDescriptor
 		this.linkedDog = null;
 	}
 
+    #region Object Overrides 
+
+    public override string ToString ()
+    {
+        return string.Format("Dog: {0}, {1}, {2}", 
+            Name,
+            Breed,
+            Age);
+    }
+
+    #endregion
+
 }


### PR DESCRIPTION
**Scripts**
- Adding `ToString` override to `DogDescriptor`
- Check Current Candidates for Shelter Dogs while also checking to see if Candidates Have Yet to be Adopted (using a `HashSet` for fast lookups)