### PR TITLE
Fixed Canvas Sorting of DogProfile & DogBrowser

### DIFF
--- a/Assets/Scenes/LivingRoom.unity
+++ b/Assets/Scenes/LivingRoom.unity
@@ -216,22 +216,22 @@ Prefab:
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 375.14185
+      value: 374.42023
       objectReference: {fileID: 0}
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -304.5
       objectReference: {fileID: 0}
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 718.2837
+      value: 716.84045
       objectReference: {fileID: 0}
     - target: {fileID: 224202790957519010, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 609
       objectReference: {fileID: 0}
     - target: {fileID: 114283656062771058, guid: e960505a4914f054cb3aa0ffbda66153,
         type: 2}
@@ -362,7 +362,7 @@ Prefab:
     - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 63.296665
       objectReference: {fileID: 0}
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -382,7 +382,7 @@ Prefab:
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -149.245
       objectReference: {fileID: 0}
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -392,7 +392,7 @@ Prefab:
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 155.89667
       objectReference: {fileID: 0}
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -412,7 +412,7 @@ Prefab:
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -293
       objectReference: {fileID: 0}
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -422,7 +422,7 @@ Prefab:
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 57.806664
       objectReference: {fileID: 0}
     - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -447,7 +447,7 @@ Prefab:
     - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 63.296665
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -467,7 +467,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -149.245
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -477,7 +477,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 155.89667
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -497,7 +497,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -293
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -507,7 +507,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 57.806664
       objectReference: {fileID: 0}
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -532,7 +532,7 @@ Prefab:
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 63.296665
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -552,7 +552,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -149.245
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -562,7 +562,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 155.89667
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -582,7 +582,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -293
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -592,7 +592,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 57.806664
       objectReference: {fileID: 0}
     - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -617,7 +617,7 @@ Prefab:
     - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 63.296665
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -637,7 +637,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -149.245
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -647,7 +647,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 155.89667
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -667,7 +667,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -293
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -677,7 +677,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 57.806664
       objectReference: {fileID: 0}
     - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1374,6 +1374,16 @@ Prefab:
       propertyPath: mainMenu
       value: 
       objectReference: {fileID: 301176092}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogProfile
+      value: 
+      objectReference: {fileID: 2025854224}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogBrowser
+      value: 
+      objectReference: {fileID: 1678609918}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 437a8e25c3d87014d9fe0dc6bbeab588, type: 2}
   m_IsPrefabParent: 0
@@ -1783,6 +1793,12 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5e902f4eaa4321f41bb54172e44ac30c, type: 2}
   m_IsPrefabParent: 0
+--- !u!114 &2025854224 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114641595301203040, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+    type: 2}
+  m_PrefabInternal: {fileID: 2025854223}
+  m_Script: {fileID: 11500000, guid: 7e590b60e7a843544b03feaa957fcc8d, type: 3}
 --- !u!1 &2088450532
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Shelter.unity
+++ b/Assets/Scenes/Shelter.unity
@@ -307,7 +307,7 @@ Prefab:
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 156.11002
+      value: 114.078964
       objectReference: {fileID: 0}
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -317,7 +317,7 @@ Prefab:
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 282.22003
+      value: 198.15793
       objectReference: {fileID: 0}
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -337,7 +337,7 @@ Prefab:
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 443.23004
+      value: 317.1369
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -347,7 +347,7 @@ Prefab:
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 282.22003
+      value: 198.15793
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -367,7 +367,7 @@ Prefab:
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 785.1334
+      value: 574.97815
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -377,7 +377,7 @@ Prefab:
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 391.7867
+      value: 307.7246
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -514,7 +514,7 @@ Prefab:
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 287.90668
+      value: 224.8601
       objectReference: {fileID: 0}
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
@@ -524,7 +524,7 @@ Prefab:
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 543.81335
+      value: 417.7202
       objectReference: {fileID: 0}
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
@@ -544,7 +544,7 @@ Prefab:
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 782.42004
+      value: 593.28033
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
@@ -554,7 +554,7 @@ Prefab:
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 405.21338
+      value: 279.1202
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
@@ -566,6 +566,16 @@ Prefab:
       propertyPath: mainMenu
       value: 
       objectReference: {fileID: 620899895}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogProfile
+      value: 
+      objectReference: {fileID: 1125526622}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogBrowser
+      value: 
+      objectReference: {fileID: 287192428}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 437a8e25c3d87014d9fe0dc6bbeab588, type: 2}
   m_IsPrefabParent: 0
@@ -718,12 +728,12 @@ Prefab:
     - target: {fileID: 224526051125565212, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 128.26646
+      value: 71.6349
       objectReference: {fileID: 0}
     - target: {fileID: 224526051125565212, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -108.363525
+      value: -108.800446
       objectReference: {fileID: 0}
     - target: {fileID: 224526051125565212, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
@@ -748,12 +758,12 @@ Prefab:
     - target: {fileID: 224590029691540520, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 268.26648
+      value: 211.6349
       objectReference: {fileID: 0}
     - target: {fileID: 224590029691540520, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -108.363525
+      value: -108.800446
       objectReference: {fileID: 0}
     - target: {fileID: 224590029691540520, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
@@ -778,12 +788,12 @@ Prefab:
     - target: {fileID: 224456034165766474, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 128.26646
+      value: 71.6349
       objectReference: {fileID: 0}
     - target: {fileID: 224456034165766474, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -248.36353
+      value: -248.80045
       objectReference: {fileID: 0}
     - target: {fileID: 224456034165766474, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
@@ -808,12 +818,12 @@ Prefab:
     - target: {fileID: 224426102182742518, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 268.26648
+      value: 211.6349
       objectReference: {fileID: 0}
     - target: {fileID: 224426102182742518, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -248.36353
+      value: -248.80045
       objectReference: {fileID: 0}
     - target: {fileID: 224426102182742518, guid: 1de9a7bb5f44ff44faa1fda4841e3cd8,
         type: 2}
@@ -1036,6 +1046,12 @@ GameObject:
   m_PrefabParentObject: {fileID: 1000469891484016, guid: ebb1f312e95b2114e9dc0dbf8acc8e62,
     type: 2}
   m_PrefabInternal: {fileID: 1125526619}
+--- !u!114 &1125526622 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114609608984700320, guid: ebb1f312e95b2114e9dc0dbf8acc8e62,
+    type: 2}
+  m_PrefabInternal: {fileID: 1125526619}
+  m_Script: {fileID: 11500000, guid: a9d5497cb2a6ca24da7070303414681c, type: 3}
 --- !u!1001 &1204983102
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Shop.unity
+++ b/Assets/Scenes/Shop.unity
@@ -198,6 +198,11 @@ Prefab:
       propertyPath: navigationPanel
       value: 
       objectReference: {fileID: 1604703934}
+    - target: {fileID: 114220403255730712, guid: 5b01ec2794e7495499d00b80f270b6ae,
+        type: 2}
+      propertyPath: dogProfileObject
+      value: 
+      objectReference: {fileID: 812233411}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5b01ec2794e7495499d00b80f270b6ae, type: 2}
   m_IsPrefabParent: 0
@@ -406,6 +411,117 @@ GameObject:
   m_PrefabParentObject: {fileID: 1425115051427350, guid: d6ec415babf284b1dbce7631f7ff192a,
     type: 2}
   m_PrefabInternal: {fileID: 1703789333}
+--- !u!1001 &812233410
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224708642269547438, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5e902f4eaa4321f41bb54172e44ac30c, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1 &812233411 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1591753207718850, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+    type: 2}
+  m_PrefabInternal: {fileID: 812233410}
+--- !u!114 &812233412 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114641595301203040, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+    type: 2}
+  m_PrefabInternal: {fileID: 812233410}
+  m_Script: {fileID: 11500000, guid: 7e590b60e7a843544b03feaa957fcc8d, type: 3}
 --- !u!114 &1019415487 stripped
 MonoBehaviour:
   m_PrefabParentObject: {fileID: 114976671936204298, guid: eb802c41a65744e4c956efbad2bc39af,
@@ -661,6 +777,16 @@ Prefab:
       propertyPath: mainMenu
       value: 
       objectReference: {fileID: 1019415487}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogProfile
+      value: 
+      objectReference: {fileID: 812233412}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogBrowser
+      value: 
+      objectReference: {fileID: 1703789334}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 437a8e25c3d87014d9fe0dc6bbeab588, type: 2}
   m_IsPrefabParent: 0
@@ -821,7 +947,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4732372126446992, guid: 6c18c567384a5444e8446d670695ec79, type: 2}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 6c18c567384a5444e8446d670695ec79, type: 2}
@@ -992,7 +1118,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1604703934 stripped
 MonoBehaviour:

--- a/Assets/Scenes/Yard.unity
+++ b/Assets/Scenes/Yard.unity
@@ -196,6 +196,12 @@ GameObject:
   m_PrefabParentObject: {fileID: 1591753207718850, guid: 5e902f4eaa4321f41bb54172e44ac30c,
     type: 2}
   m_PrefabInternal: {fileID: 80994045}
+--- !u!114 &80994047 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114641595301203040, guid: 5e902f4eaa4321f41bb54172e44ac30c,
+    type: 2}
+  m_PrefabInternal: {fileID: 80994045}
+  m_Script: {fileID: 11500000, guid: 7e590b60e7a843544b03feaa957fcc8d, type: 3}
 --- !u!1001 &180024929
 Prefab:
   m_ObjectHideFlags: 0
@@ -653,22 +659,22 @@ Prefab:
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 500.25
+      value: 374.42023
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -304.5
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 968.5
+      value: 716.84045
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 0
+      value: 609
       objectReference: {fileID: 0}
     - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
@@ -1512,7 +1518,7 @@ Prefab:
     - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1532,7 +1538,7 @@ Prefab:
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1542,7 +1548,7 @@ Prefab:
     - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1562,7 +1568,7 @@ Prefab:
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1572,7 +1578,7 @@ Prefab:
     - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1972,7 +1978,7 @@ Prefab:
     - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1992,7 +1998,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2002,7 +2008,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2022,7 +2028,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2032,7 +2038,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2057,7 +2063,7 @@ Prefab:
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2077,7 +2083,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2087,7 +2093,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2107,7 +2113,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2117,7 +2123,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2142,7 +2148,7 @@ Prefab:
     - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2162,7 +2168,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2172,7 +2178,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2192,7 +2198,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -2202,7 +2208,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: b266d74ebb57040989170e55fc04a2ff, type: 2}
@@ -2431,6 +2437,16 @@ Prefab:
       propertyPath: mainMenu
       value: 
       objectReference: {fileID: 970095801}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogProfile
+      value: 
+      objectReference: {fileID: 80994047}
+    - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
+        type: 2}
+      propertyPath: dogBrowser
+      value: 
+      objectReference: {fileID: 1836214344}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 437a8e25c3d87014d9fe0dc6bbeab588, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scripts/UI/PickupPup/Core/PPUIController.cs
+++ b/Assets/Scripts/UI/PickupPup/Core/PPUIController.cs
@@ -96,7 +96,6 @@ public class PPUIController : MonoBehaviourExtended
 
 	void handleDogSlotClicked(Dog dog)
 	{
-        // TODO: Insert universal dog slot handle code here
         if (dogProfileObject)
         {
         	showDogProfile(dog);
@@ -111,12 +110,14 @@ public class PPUIController : MonoBehaviourExtended
         {
             dogProfile = dogProfileObject.GetComponent<DogProfile>();
         }
+        dogProfile.Show();
         dogProfile.SetProfile(dog);
     }
 
     protected virtual void showPopupPrompt()
     {
         PopupPrompt prompt = (PopupPrompt) Instantiate(popupPrompt);
+        prompt.GetComponent<PPUIElement>().Show();
         prompt.Set(promptID);
     }
 

--- a/Assets/Scripts/UI/PickupPup/DogBrowser/DogBrowser.cs
+++ b/Assets/Scripts/UI/PickupPup/DogBrowser/DogBrowser.cs
@@ -134,6 +134,7 @@ public class DogBrowser : PPUIElement, IPageable
 
     public override void Hide()
 	{
+        checkReferences();
         if(gameController.HasTargetSlot)
         {
             gameController.ClearTargetSlot();

--- a/Assets/Scripts/UI/PickupPup/NavPanel/NavigationPanel.cs
+++ b/Assets/Scripts/UI/PickupPup/NavPanel/NavigationPanel.cs
@@ -15,6 +15,10 @@ public class NavigationPanel : SingletonController<NavigationPanel>
     Button adoptButton;
     [SerializeField]
     MainMenu mainMenu;
+    [SerializeField]
+    DogProfile dogProfile;
+    [SerializeField]
+    DogBrowser dogBrowser;
 
     PPSceneController sceneController;
 
@@ -39,6 +43,14 @@ public class NavigationPanel : SingletonController<NavigationPanel>
     public void OnMenuClick()
     {
         mainMenu.Toggle();
+        if(dogProfile)
+        {
+            dogProfile.Hide();
+        }
+        if(dogBrowser)
+        {
+            dogBrowser.Hide();
+        }
     }
 
     public void OnAdoptClick()


### PR DESCRIPTION
Fixed bug: DogProfile and DogBrowser did not appear on top when they were already showing underneath

**Scenes**
-  Shop, LivingRoom, Yard, Shelter: added refs on NavigationPanel to DogProfile & DogBrowser

**Scripts**
- PPUIController: uses DogProfile's Show method rather than only setting active
- DogBrowser: added checkReferences() in Hide method
- NavigationPanel: added code to hide DogProfile & DogBrowser when the menu button is pressed