### PR TITLE
Add Radial fill to yard scouting

### DIFF
--- a/Assets/Prefabs/PickupPup/Core/UI/ScoutingUI.prefab
+++ b/Assets/Prefabs/PickupPup/Core/UI/ScoutingUI.prefab
@@ -100,16 +100,36 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1156419424034442
+--- !u!1 &1139588459480414
 GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 224964545336709914}
-  - component: {fileID: 222143822552912536}
-  - component: {fileID: 114378546534123568}
+  - component: {fileID: 224546046784495494}
+  - component: {fileID: 222119165720982758}
+  - component: {fileID: 114391343143741048}
+  - component: {fileID: 114784792208126402}
+  - component: {fileID: 114287962559679152}
+  - component: {fileID: 114623100523702468}
+  m_Layer: 5
+  m_Name: DogButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1167876503891152
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224008879257676002}
+  - component: {fileID: 222635095662947508}
+  - component: {fileID: 114524949152633296}
   m_Layer: 5
   m_Name: RedeemableGiftOverlay
   m_TagString: Untagged
@@ -146,10 +166,42 @@ GameObject:
   - component: {fileID: 222307330806769936}
   - component: {fileID: 114419583983487042}
   - component: {fileID: 114493356325385012}
-  - component: {fileID: 114174295931590266}
-  - component: {fileID: 114123002901914490}
   m_Layer: 5
-  m_Name: DogButton
+  m_Name: RadialFill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!1 &1185162934273880
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224956125703099786}
+  - component: {fileID: 222624886998243324}
+  - component: {fileID: 114447857175546994}
+  m_Layer: 5
+  m_Name: GiftIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1266703042957544
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224554009574422166}
+  - component: {fileID: 222149394826281244}
+  - component: {fileID: 114446778359695350}
+  m_Layer: 5
+  m_Name: DogSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -173,6 +225,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1288316796933884
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224092067050624474}
+  - component: {fileID: 222583748609818242}
+  - component: {fileID: 114739445524701134}
+  - component: {fileID: 114094890117450310}
+  - component: {fileID: 114174295931590266}
+  - component: {fileID: 114123002901914490}
+  m_Layer: 5
+  m_Name: DogButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1316730209352020
 GameObject:
   m_ObjectHideFlags: 1
@@ -190,23 +262,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1320380650052248
-GameObject:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 224068024718351062}
-  - component: {fileID: 222116401498556466}
-  - component: {fileID: 114097288665542500}
-  m_Layer: 5
-  m_Name: RedeemableGiftOverlay
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
 --- !u!1 &1335315674781014
 GameObject:
   m_ObjectHideFlags: 1
@@ -218,15 +273,13 @@ GameObject:
   - component: {fileID: 222326563311156374}
   - component: {fileID: 114474812300691352}
   - component: {fileID: 114785620125203162}
-  - component: {fileID: 114762290802962940}
-  - component: {fileID: 114540223467993376}
   m_Layer: 5
-  m_Name: DogButton
+  m_Name: RadialFill
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1366363911849052
 GameObject:
   m_ObjectHideFlags: 1
@@ -240,6 +293,26 @@ GameObject:
   - component: {fileID: 114443195930469880}
   m_Layer: 5
   m_Name: TimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1446488100718898
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224869306311040010}
+  - component: {fileID: 222908017387985164}
+  - component: {fileID: 114155910802911698}
+  - component: {fileID: 114455658465084504}
+  - component: {fileID: 114762290802962940}
+  - component: {fileID: 114540223467993376}
+  m_Layer: 5
+  m_Name: DogButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -315,7 +388,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1503264567318390
 GameObject:
   m_ObjectHideFlags: 1
@@ -344,15 +417,13 @@ GameObject:
   - component: {fileID: 222705714999605356}
   - component: {fileID: 114286412032861440}
   - component: {fileID: 114960908702955256}
-  - component: {fileID: 114359064691774216}
-  - component: {fileID: 114075125956694080}
   m_Layer: 5
-  m_Name: DogButton
+  m_Name: RadialFill
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1562607416654716
 GameObject:
   m_ObjectHideFlags: 1
@@ -381,15 +452,13 @@ GameObject:
   - component: {fileID: 222389598735732986}
   - component: {fileID: 114431236806783644}
   - component: {fileID: 114948459228356576}
-  - component: {fileID: 114661352456223138}
-  - component: {fileID: 114272026242105860}
   m_Layer: 5
-  m_Name: DogButton
+  m_Name: RadialFill
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1607421685831154
 GameObject:
   m_ObjectHideFlags: 1
@@ -444,18 +513,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1690221464732762
+--- !u!1 &1663995958914050
 GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 224437757160744758}
-  - component: {fileID: 222255889026794304}
-  - component: {fileID: 114608040973346054}
+  - component: {fileID: 224412932612796368}
+  - component: {fileID: 222532061527963596}
+  - component: {fileID: 114734645449932500}
   m_Layer: 5
-  m_Name: GiftIcon
+  m_Name: DogSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -495,7 +564,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1713075325254658
 GameObject:
   m_ObjectHideFlags: 1
@@ -514,18 +583,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1775739026333660
+--- !u!1 &1757209079395248
 GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 224163679432926842}
-  - component: {fileID: 222425078982765718}
-  - component: {fileID: 114420892190013458}
+  - component: {fileID: 224678922198266448}
+  - component: {fileID: 222703962931382194}
+  - component: {fileID: 114680970092467664}
   m_Layer: 5
-  m_Name: GiftIcon
+  m_Name: DogSprite
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -563,7 +632,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1798783428315280
 GameObject:
   m_ObjectHideFlags: 1
@@ -577,6 +646,26 @@ GameObject:
   - component: {fileID: 114224014303203040}
   m_Layer: 5
   m_Name: DogCollarSlot (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1822339484066576
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224707014508813868}
+  - component: {fileID: 222720095562239412}
+  - component: {fileID: 114636893678355152}
+  - component: {fileID: 114060775288260238}
+  - component: {fileID: 114640579938220488}
+  - component: {fileID: 114104458507569416}
+  m_Layer: 5
+  m_Name: DogButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -609,6 +698,23 @@ GameObject:
   - component: {fileID: 224077383578211136}
   - component: {fileID: 222586447365065994}
   - component: {fileID: 114926488013858912}
+  m_Layer: 5
+  m_Name: DogSprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!1 &1858179568394120
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224493619445001926}
+  - component: {fileID: 222800922280254574}
+  - component: {fileID: 114147694626338046}
   m_Layer: 5
   m_Name: DogSprite
   m_TagString: Untagged
@@ -685,6 +791,40 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
+--- !u!1 &1963767321862206
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224442743733098326}
+  - component: {fileID: 222228165637504626}
+  - component: {fileID: 114579222392547270}
+  m_Layer: 5
+  m_Name: RedeemableGiftOverlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!1 &1994833760960228
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224921833776681252}
+  - component: {fileID: 222885812289790148}
+  - component: {fileID: 114158394486304740}
+  m_Layer: 5
+  m_Name: GiftIcon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!114 &114015951413783938
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -730,11 +870,12 @@ MonoBehaviour:
   alternateSprites: []
   shouldCollectInSpawnPool: 1
   backgroundImage: {fileID: 0}
-  dogImage: {fileID: 114926488013858912}
-  dogImageOverride: {fileID: 114926488013858912}
-  redeemableGiftIcon: {fileID: 114608040973346054}
-  redeemableGiftDisplay: {fileID: 1320380650052248}
+  dogImage: {fileID: 114147694626338046}
+  dogImageOverride: {fileID: 114147694626338046}
+  redeemableGiftIcon: {fileID: 114447857175546994}
+  redeemableGiftDisplay: {fileID: 1963767321862206}
   collarSprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  radialFill: {fileID: 114286412032861440}
 --- !u!114 &114037821020654296
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -751,21 +892,18 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
---- !u!114 &114075125956694080
+--- !u!114 &114060775288260238
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1535744161361296}
+  m_GameObject: {fileID: 1822339484066576}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
+  m_Script: {fileID: -1200242548, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  preserveOnSceneChange: 0
-  alternateSprites: []
-  shouldCollectInSpawnPool: 1
-  suppressStandardSFX: 1
+  m_ShowMaskGraphic: 1
 --- !u!114 &114078038025909430
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -784,39 +922,39 @@ MonoBehaviour:
   m_PreferredHeight: 112.6
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
---- !u!114 &114097288665542500
+--- !u!114 &114094890117450310
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1320380650052248}
+  m_GameObject: {fileID: 1288316796933884}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: -1200242548, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.49019608}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
+  m_ShowMaskGraphic: 1
+--- !u!114 &114104458507569416
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1822339484066576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  preserveOnSceneChange: 0
+  alternateSprites: []
+  shouldCollectInSpawnPool: 1
+  suppressStandardSFX: 1
 --- !u!114 &114123002901914490
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1173494766687070}
+  m_GameObject: {fileID: 1288316796933884}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
@@ -848,6 +986,87 @@ MonoBehaviour:
   m_Sprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
   m_Type: 0
   m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114147694626338046
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1858179568394120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114155910802911698
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1446488100718898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.88235295, g: 0.49019608, b: 0.49019608, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114158394486304740
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1994833760960228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300006, guid: 0e4f901559709cf448c7176f7e211c94, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
@@ -945,7 +1164,7 @@ MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1173494766687070}
+  m_GameObject: {fileID: 1288316796933884}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
@@ -975,7 +1194,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 114419583983487042}
+  m_TargetGraphic: {fileID: 114739445524701134}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -1023,11 +1242,12 @@ MonoBehaviour:
   alternateSprites: []
   shouldCollectInSpawnPool: 1
   backgroundImage: {fileID: 0}
-  dogImage: {fileID: 114142573006053510}
-  dogImageOverride: {fileID: 114142573006053510}
+  dogImage: {fileID: 114446778359695350}
+  dogImageOverride: {fileID: 114446778359695350}
   redeemableGiftIcon: {fileID: 114748406835887326}
   redeemableGiftDisplay: {fileID: 1842056062576948}
   collarSprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  radialFill: {fileID: 114419583983487042}
 --- !u!114 &114191908769123666
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1128,21 +1348,6 @@ MonoBehaviour:
   m_PreferredHeight: 20
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
---- !u!114 &114272026242105860
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1594626337851910}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  preserveOnSceneChange: 0
-  alternateSprites: []
-  shouldCollectInSpawnPool: 1
-  suppressStandardSFX: 1
 --- !u!114 &114276156683912222
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1233,15 +1438,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.4766436, g: 0.66609, b: 0.85294116, a: 1}
+  m_Color: {r: 0.7647059, g: 0.7651832, b: 0.7647059, a: 0.7490196}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
-  m_Type: 1
+  m_Sprite: {fileID: 21300002, guid: 438a896320124094fa3f7102729eb15b, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1266,12 +1471,12 @@ MonoBehaviour:
   m_PreferredHeight: 14.51
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
---- !u!114 &114359064691774216
+--- !u!114 &114287962559679152
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1535744161361296}
+  m_GameObject: {fileID: 1139588459480414}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
@@ -1301,7 +1506,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 114286412032861440}
+  m_TargetGraphic: {fileID: 114391343143741048}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -1346,33 +1551,6 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!114 &114378546534123568
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1156419424034442}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0, b: 0, a: 0.49019608}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
 --- !u!114 &114380948202782610
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1395,19 +1573,19 @@ MonoBehaviour:
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
   m_ChildControlHeight: 1
---- !u!114 &114419583983487042
+--- !u!114 &114391343143741048
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1173494766687070}
+  m_GameObject: {fileID: 1139588459480414}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.73333335, g: 0.98039216, b: 0.85882354, a: 1}
+  m_Color: {r: 0.4766436, g: 0.66609, b: 0.85294116, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1422,27 +1600,27 @@ MonoBehaviour:
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!114 &114420892190013458
+--- !u!114 &114419583983487042
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1775739026333660}
+  m_GameObject: {fileID: 1173494766687070}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.7647059, g: 0.7647059, b: 0.7647059, a: 0.7490196}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300006, guid: 0e4f901559709cf448c7176f7e211c94, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1494,7 +1672,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.8666667, g: 0.70980394, b: 0.7882353, a: 1}
+  m_Color: {r: 0.7647059, g: 0.7647059, b: 0.7647059, a: 0.7490196}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -1502,7 +1680,7 @@ MonoBehaviour:
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
-  m_Type: 1
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1572,6 +1750,72 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 1
+--- !u!114 &114446778359695350
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1266703042957544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114447857175546994
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1185162934273880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300006, guid: 0e4f901559709cf448c7176f7e211c94, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114455658465084504
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1446488100718898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1200242548, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!114 &114468576262929048
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1618,15 +1862,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.88235295, g: 0.49019608, b: 0.49019608, a: 1}
+  m_Color: {r: 0.7647059, g: 0.7647059, b: 0.7647059, a: 0.7490196}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
-  m_Type: 1
+  m_Sprite: {fileID: 21300002, guid: 438a896320124094fa3f7102729eb15b, type: 3}
+  m_Type: 3
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1705,17 +1949,45 @@ MonoBehaviour:
   alternateSprites: []
   shouldCollectInSpawnPool: 1
   backgroundImage: {fileID: 0}
-  dogImage: {fileID: 114507880422119872}
-  dogImageOverride: {fileID: 114507880422119872}
+  dogImage: {fileID: 114734645449932500}
+  dogImageOverride: {fileID: 114734645449932500}
   redeemableGiftIcon: {fileID: 114164665223429018}
   redeemableGiftDisplay: {fileID: 1945115852732152}
   collarSprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  radialFill: {fileID: 114431236806783644}
+--- !u!114 &114524949152633296
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1167876503891152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.49019608}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &114540223467993376
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1335315674781014}
+  m_GameObject: {fileID: 1446488100718898}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
@@ -1725,6 +1997,33 @@ MonoBehaviour:
   alternateSprites: []
   shouldCollectInSpawnPool: 1
   suppressStandardSFX: 1
+--- !u!114 &114579222392547270
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1963767321862206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.49019608}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &114604452868063276
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1743,33 +2042,89 @@ MonoBehaviour:
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
---- !u!114 &114608040973346054
+--- !u!114 &114623100523702468
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1690221464732762}
+  m_GameObject: {fileID: 1139588459480414}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 1b54f762609fe48cba586ac4228edb7e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  preserveOnSceneChange: 0
+  alternateSprites: []
+  shouldCollectInSpawnPool: 1
+  suppressStandardSFX: 1
+--- !u!114 &114636893678355152
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1822339484066576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.8666667, g: 0.70980394, b: 0.7882353, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300006, guid: 0e4f901559709cf448c7176f7e211c94, type: 3}
-  m_Type: 0
+  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
+  m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
+--- !u!114 &114640579938220488
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1822339484066576}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 114636893678355152}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
 --- !u!114 &114641360146701124
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1843,47 +2198,33 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 00:00
---- !u!114 &114661352456223138
+--- !u!114 &114680970092467664
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1594626337851910}
+  m_GameObject: {fileID: 1757209079395248}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 1, g: 1, b: 1, a: 1}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 114431236806783644}
-  m_OnClick:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &114702515647772508
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1917,6 +2258,60 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 00:00
+--- !u!114 &114734645449932500
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1663995958914050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114739445524701134
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1288316796933884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.73333335, g: 0.98039216, b: 0.85882354, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300002, guid: 622a4c7549d360a4da977bf3f8088959, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!114 &114748406835887326
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -1949,7 +2344,7 @@ MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1335315674781014}
+  m_GameObject: {fileID: 1446488100718898}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
@@ -1979,7 +2374,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 114474812300691352}
+  m_TargetGraphic: {fileID: 114155910802911698}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -2018,6 +2413,18 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 00:00
+--- !u!114 &114784792208126402
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1139588459480414}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1200242548, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 1
 --- !u!114 &114785620125203162
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2353,11 +2760,12 @@ MonoBehaviour:
   alternateSprites: []
   shouldCollectInSpawnPool: 1
   backgroundImage: {fileID: 0}
-  dogImage: {fileID: 114180684945264686}
-  dogImageOverride: {fileID: 114180684945264686}
-  redeemableGiftIcon: {fileID: 114420892190013458}
-  redeemableGiftDisplay: {fileID: 1156419424034442}
+  dogImage: {fileID: 114680970092467664}
+  dogImageOverride: {fileID: 114680970092467664}
+  redeemableGiftIcon: {fileID: 114158394486304740}
+  redeemableGiftDisplay: {fileID: 1167876503891152}
   collarSprite: {fileID: 21300000, guid: 913c358fed8924ba485ee5bb66599ae7, type: 3}
+  radialFill: {fileID: 114474812300691352}
 --- !u!114 &114991572409725282
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -2388,30 +2796,30 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1003774973032482}
---- !u!222 &222116401498556466
+--- !u!222 &222119165720982758
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1320380650052248}
---- !u!222 &222143822552912536
+  m_GameObject: {fileID: 1139588459480414}
+--- !u!222 &222149394826281244
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1156419424034442}
+  m_GameObject: {fileID: 1266703042957544}
 --- !u!222 &222175036918034512
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1284066975730718}
---- !u!222 &222255889026794304
+--- !u!222 &222228165637504626
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1690221464732762}
+  m_GameObject: {fileID: 1963767321862206}
 --- !u!222 &222284977068301356
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2454,12 +2862,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1594626337851910}
---- !u!222 &222425078982765718
-CanvasRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1775739026333660}
 --- !u!222 &222450173996686452
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2484,18 +2886,42 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1503264567318390}
+--- !u!222 &222532061527963596
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1663995958914050}
 --- !u!222 &222574295369305192
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1607421685831154}
+--- !u!222 &222583748609818242
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1288316796933884}
 --- !u!222 &222586447365065994
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1845244795174160}
+--- !u!222 &222624886998243324
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1185162934273880}
+--- !u!222 &222635095662947508
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1167876503891152}
 --- !u!222 &222637117527390894
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2514,6 +2940,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1562607416654716}
+--- !u!222 &222703962931382194
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1757209079395248}
 --- !u!222 &222705714999605356
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2526,6 +2958,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1923277382745754}
+--- !u!222 &222720095562239412
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1822339484066576}
 --- !u!222 &222725706433278804
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2538,12 +2976,30 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1713075325254658}
+--- !u!222 &222800922280254574
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1858179568394120}
 --- !u!222 &222841103674797618
 CanvasRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1621392223114104}
+--- !u!222 &222885812289790148
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1994833760960228}
+--- !u!222 &222908017387985164
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1446488100718898}
 --- !u!222 &222972654137291074
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -2587,6 +3043,25 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224008879257676002
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1167876503891152}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224921833776681252}
+  m_Father: {fileID: 224869306311040010}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224024026868098546
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2605,25 +3080,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
---- !u!224 &224068024718351062
-RectTransform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1320380650052248}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 224437757160744758}
-  m_Father: {fileID: 224144440071112322}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224072970196579500
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2678,6 +3134,26 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
+--- !u!224 &224092067050624474
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1288316796933884}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224554009574422166}
+  - {fileID: 224921307816819566}
+  m_Father: {fileID: 224153989083695060}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224105782166780886
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2686,16 +3162,15 @@ RectTransform:
   m_GameObject: {fileID: 1173494766687070}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.0000062, y: 1.0000062, z: 1.0000062}
   m_Children:
   - {fileID: 224007525804914818}
-  - {fileID: 224921307816819566}
   m_Father: {fileID: 224153989083695060}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_AnchoredPosition: {x: 0.000030517578, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224144440071112322
@@ -2706,16 +3181,15 @@ RectTransform:
   m_GameObject: {fileID: 1535744161361296}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.9999962, y: 0.9999962, z: 0.9999962}
   m_Children:
   - {fileID: 224077383578211136}
-  - {fileID: 224068024718351062}
   m_Father: {fileID: 224874693334606402}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_AnchoredPosition: {x: 0.000030517578, y: -0.000015258789}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224153989083695060
@@ -2728,6 +3202,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 224092067050624474}
   - {fileID: 224105782166780886}
   - {fileID: 224892910200029698}
   m_Father: {fileID: 224302494560007898}
@@ -2737,24 +3212,6 @@ RectTransform:
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &224163679432926842
-RectTransform:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1775739026333660}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 224964545336709914}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224187523304882570
 RectTransform:
@@ -2766,6 +3223,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 224707014508813868}
   - {fileID: 224273463395775610}
   - {fileID: 224298998562477348}
   m_Father: {fileID: 224772698414921936}
@@ -2802,16 +3260,15 @@ RectTransform:
   m_GameObject: {fileID: 1594626337851910}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.0000062, y: 1.0000062, z: 1.0000062}
   m_Children:
   - {fileID: 224189172999366148}
-  - {fileID: 224647657110702512}
   m_Father: {fileID: 224187523304882570}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_AnchoredPosition: {x: -0.000061035156, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224298998562477348
@@ -2825,7 +3282,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224187523304882570}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2919,35 +3376,53 @@ RectTransform:
   m_GameObject: {fileID: 1335315674781014}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.0000062, y: 1.0000062, z: 1.0000062}
   m_Children:
   - {fileID: 224481095099136832}
-  - {fileID: 224964545336709914}
   m_Father: {fileID: 224928207616995372}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_AnchoredPosition: {x: -0.000030517578, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &224437757160744758
+--- !u!224 &224412932612796368
 RectTransform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1690221464732762}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1663995958914050}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 224068024718351062}
+  m_Father: {fileID: 224707014508813868}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224442743733098326
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1963767321862206}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224956125703099786}
+  m_Father: {fileID: 224546046784495494}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224479789599895554
 RectTransform:
@@ -2988,6 +3463,24 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224493619445001926
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1858179568394120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224546046784495494}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224542397797300880
 RectTransform:
   m_ObjectHideFlags: 1
@@ -2999,7 +3492,27 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224874693334606402}
-  m_RootOrder: 1
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224546046784495494
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1139588459480414}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224493619445001926}
+  - {fileID: 224442743733098326}
+  m_Father: {fileID: 224874693334606402}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3017,11 +3530,29 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224928207616995372}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224554009574422166
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1266703042957544}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224092067050624474}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224575086644616346
@@ -3071,12 +3602,50 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 224072970196579500}
-  m_Father: {fileID: 224273463395775610}
+  m_Father: {fileID: 224707014508813868}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224678922198266448
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1757209079395248}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224869306311040010}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224707014508813868
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1822339484066576}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224412932612796368}
+  - {fileID: 224647657110702512}
+  m_Father: {fileID: 224187523304882570}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224772698414921936
@@ -3158,6 +3727,26 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!224 &224869306311040010
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1446488100718898}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224678922198266448}
+  - {fileID: 224008879257676002}
+  m_Father: {fileID: 224928207616995372}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0000076293945, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224874693334606402
 RectTransform:
   m_ObjectHideFlags: 1
@@ -3168,6 +3757,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 224546046784495494}
   - {fileID: 224144440071112322}
   - {fileID: 224542397797300880}
   m_Father: {fileID: 224479789599895554}
@@ -3207,7 +3797,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224153989083695060}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3225,13 +3815,31 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 224618106144302690}
-  m_Father: {fileID: 224105782166780886}
+  m_Father: {fileID: 224092067050624474}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224921833776681252
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1994833760960228}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224008879257676002}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224928207616995372
 RectTransform:
@@ -3243,6 +3851,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 224869306311040010}
   - {fileID: 224408703426534296}
   - {fileID: 224553211621222306}
   m_Father: {fileID: 224370645586166540}
@@ -3253,24 +3862,23 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!224 &224964545336709914
+--- !u!224 &224956125703099786
 RectTransform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1156419424034442}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 1185162934273880}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 224163679432926842}
-  m_Father: {fileID: 224408703426534296}
-  m_RootOrder: 1
+  m_Children: []
+  m_Father: {fileID: 224442743733098326}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224978594526050140
 RectTransform:

--- a/Assets/Scenes/Yard.unity
+++ b/Assets/Scenes/Yard.unity
@@ -312,22 +312,22 @@ Prefab:
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 128.23056
+      value: 322.77222
       objectReference: {fileID: 0}
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -75
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 226.4611
+      value: 615.54443
       objectReference: {fileID: 0}
     - target: {fileID: 224900804115513876, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 110
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -342,22 +342,22 @@ Prefab:
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 359.59164
+      value: 943.2167
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -75
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 226.4611
+      value: 615.54443
       objectReference: {fileID: 0}
     - target: {fileID: 224659772495038526, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 110
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
@@ -372,22 +372,22 @@ Prefab:
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 645.7361
+      value: 1618.4445
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -75
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 336.02777
+      value: 725.1111
       objectReference: {fileID: 0}
     - target: {fileID: 224609788372452216, guid: 8d69af9264e9c13488259a47880b0431,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 110
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 8d69af9264e9c13488259a47880b0431, type: 2}
@@ -491,6 +491,571 @@ Prefab:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: bb45bc5c245b0744eb14f3243080f954, type: 2}
+  m_IsPrefabParent: 0
+--- !u!1001 &666540735
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114903807162365386, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: dogBrowser
+      value: 
+      objectReference: {fileID: 1836214344}
+    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 63.296665
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -149.245
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 155.89667
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -293
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 57.806664
+      objectReference: {fileID: 0}
+    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 63.296665
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -149.245
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 155.89667
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -293
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 57.806664
+      objectReference: {fileID: 0}
+    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 63.296665
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -149.245
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 155.89667
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -293
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 57.806664
+      objectReference: {fileID: 0}
+    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 63.296665
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -149.245
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 155.89667
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 87.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -293
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 57.806664
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 107.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 302.65002
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 497.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 692.85004
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 175.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: b266d74ebb57040989170e55fc04a2ff, type: 2}
   m_IsPrefabParent: 0
 --- !u!1001 &676491185
 Prefab:
@@ -659,7 +1224,7 @@ Prefab:
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 416.875
+      value: 1000.5
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
@@ -669,12 +1234,72 @@ Prefab:
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 801.75
+      value: 1969
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_SizeDelta.y
       value: 609
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 1000.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 2001
+      objectReference: {fileID: 0}
+    - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 1000.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 2001
+      objectReference: {fileID: 0}
+    - target: {fileID: 224371255726617122, guid: a0943fe20c1884341b951b488b9c366f,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a0943fe20c1884341b951b488b9c366f, type: 2}
@@ -848,1491 +1473,6 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 6c18c567384a5444e8446d670695ec79, type: 2}
   m_IsPrefabParent: 0
---- !u!1001 &1527557955
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_Pivot.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224374004673230728, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_Pivot.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114903807162365386, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: dogBrowser
-      value: 
-      objectReference: {fileID: 1836214344}
-    - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224369047007865744, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224975869072550674, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224700601100132838, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224930997309792688, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224121068555518516, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224999558978886970, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224486706362687550, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224459291398429686, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224561539807967068, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224274861908885300, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224136450788013878, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224598121178610766, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 107.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224280287813697166, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 302.65002
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224521770645873466, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 497.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224796909187564474, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 692.85004
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224424951920956198, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224039266598944974, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224310768440422660, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224968292364448616, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224837215037084422, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224133636777351282, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224221499582077374, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224182118101770304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224182118101770304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224182118101770304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224182118101770304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224182118101770304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224780746721295304, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224583145082487906, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224762414406156470, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224762414406156470, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224762414406156470, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224762414406156470, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224762414406156470, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224845873741574534, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224955998632043966, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 107.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224206201004695046, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 302.65002
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224156140676298328, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 497.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224558336423018080, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 692.85004
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224582180745506316, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 63.296665
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -149.245
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 155.89667
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 57.806664
-      objectReference: {fileID: 0}
-    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 63.296665
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -149.245
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 155.89667
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 57.806664
-      objectReference: {fileID: 0}
-    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 63.296665
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -149.245
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 155.89667
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 57.806664
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 302.65002
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -146.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224370645586166540, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 497.75
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -146.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224302494560007898, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 692.85004
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -146.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224772698414921936, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 63.296665
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -149.245
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 155.89667
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 87.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -293
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 57.806664
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.x
-      value: 107.55
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_AnchoredPosition.y
-      value: -146.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.x
-      value: 175.1
-      objectReference: {fileID: 0}
-    - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
-        type: 2}
-      propertyPath: m_SizeDelta.y
-      value: 293
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: b266d74ebb57040989170e55fc04a2ff, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &1655787449
 GameObject:
   m_ObjectHideFlags: 0
@@ -2505,22 +1645,22 @@ Prefab:
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 246.0875
+      value: 537.9
       objectReference: {fileID: 0}
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -67.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 460.175
+      value: 1043.8
       objectReference: {fileID: 0}
     - target: {fileID: 224666962499712972, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
@@ -2535,22 +1675,22 @@ Prefab:
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.x
-      value: 656.96246
+      value: 1532.4
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -67.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.x
-      value: 321.57498
+      value: 905.19995
       objectReference: {fileID: 0}
     - target: {fileID: 224595585500845690, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 135
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114698850581731470, guid: 437a8e25c3d87014d9fe0dc6bbeab588,
         type: 2}

--- a/Assets/Scenes/Yard.unity
+++ b/Assets/Scenes/Yard.unity
@@ -617,7 +617,7 @@ Prefab:
     - target: {fileID: 224856128351561898, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -637,7 +637,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -647,7 +647,7 @@ Prefab:
     - target: {fileID: 224153989083695060, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -667,7 +667,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -677,7 +677,7 @@ Prefab:
     - target: {fileID: 224343989594861986, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -702,7 +702,7 @@ Prefab:
     - target: {fileID: 224978594526050140, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -722,7 +722,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -732,7 +732,7 @@ Prefab:
     - target: {fileID: 224928207616995372, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -752,7 +752,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -762,7 +762,7 @@ Prefab:
     - target: {fileID: 224891571689356028, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -787,7 +787,7 @@ Prefab:
     - target: {fileID: 224823253540491168, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -807,7 +807,7 @@ Prefab:
     - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -817,7 +817,7 @@ Prefab:
     - target: {fileID: 224874693334606402, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -837,7 +837,7 @@ Prefab:
     - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -847,7 +847,7 @@ Prefab:
     - target: {fileID: 224091177309136318, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -872,7 +872,7 @@ Prefab:
     - target: {fileID: 224024026868098546, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 63.296665
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -892,7 +892,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -149.245
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -902,7 +902,7 @@ Prefab:
     - target: {fileID: 224187523304882570, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 155.89667
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -922,7 +922,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -293
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -932,7 +932,7 @@ Prefab:
     - target: {fileID: 224575086644616346, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 57.806664
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224479789599895554, guid: b266d74ebb57040989170e55fc04a2ff,
         type: 2}
@@ -1229,7 +1229,7 @@ Prefab:
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_AnchoredPosition.y
-      value: -304.5
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
@@ -1239,7 +1239,7 @@ Prefab:
     - target: {fileID: 224949507014025912, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}
       propertyPath: m_SizeDelta.y
-      value: 609
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 224919865293972966, guid: a0943fe20c1884341b951b488b9c366f,
         type: 2}

--- a/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
+++ b/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
@@ -207,8 +207,9 @@ public class DogCollarSlot : DogSlot
 
         //BP Set radialFill to be active and cover button and start lerp from the beginning
         radialFill.gameObject.SetActive(true);
-        float totalTime = dog.Info.TotalTimeToReturn;
-        StartCoroutine(lerpRadial(totalTime, totalTime));
+        float timeTotal = dog.Info.TotalTimeToReturn;
+        float timeRemaining = dog.Info.TimeRemainingScouting;
+        StartCoroutine(lerpRadial(timeRemaining, timeTotal));
     }
 
     void subscribeGiftEvents(Dog dog)

--- a/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
+++ b/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
@@ -281,14 +281,11 @@ public class DogCollarSlot : DogSlot
         float startPoint = timeRemaining / totalTime;
         float endPoint = (timeRemaining - 1) / totalTime;
         float lerpTime = 0;
-        float currentPoint = startPoint;
-        float lerpLimit = 1;
 
-        while(lerpTime < lerpLimit)
+        while(lerpTime < 1)
         {
             lerpTime += Time.deltaTime;
-            currentPoint = Mathf.Lerp(startPoint, endPoint, lerpTime);
-            radialFill.fillAmount = currentPoint;
+            radialFill.fillAmount = Mathf.Lerp(startPoint, endPoint, lerpTime);
             yield return new WaitForEndOfFrame();
         }
     }

--- a/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
+++ b/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
@@ -5,9 +5,7 @@
 
 using UnityEngine;
 using UnityEngine.UI;
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using k = PPGlobal;
 
 public class DogCollarSlot : DogSlot
@@ -55,7 +53,7 @@ public class DogCollarSlot : DogSlot
     protected override void checkReferences()
     {
         base.checkReferences();
-        if (dogImageOverride)
+        if(dogImageOverride)
         {
             dogImage = dogImageOverride;
         }
@@ -64,7 +62,7 @@ public class DogCollarSlot : DogSlot
     protected override void handleSceneLoaded(int sceneIndex)
     {
         base.handleSceneLoaded(sceneIndex);
-        if (!timerText)
+        if(!timerText)
         {
             timerText = gameObject.AddComponent<Text>();
         }
@@ -73,7 +71,7 @@ public class DogCollarSlot : DogSlot
     protected override void cleanupReferences()
     {
         base.cleanupReferences();
-        if (dog)
+        if(dog)
         {
             unsubscribeFromDogEvents(dog);
         }
@@ -114,7 +112,7 @@ public class DogCollarSlot : DogSlot
     protected override void callOnOccupiedSlotClick(Dog dog)
     {
         // Safeguard against opening up tons of copies of the panel
-        if (!redeemDisplayIsOpen)
+        if(!redeemDisplayIsOpen)
         {
             base.callOnOccupiedSlotClick(dog);
         }
@@ -147,7 +145,7 @@ public class DogCollarSlot : DogSlot
         subscribeTimerEvents(dog);
         dog.SetTimer(dogInfo.TimeRemainingScouting);
 		initDogScouting(dog, onResume: true);
-        if (dog.HasRedeemableGift)
+        if(dog.HasRedeemableGift)
         {
             handleGiftFound(dog.PeekAtGift);
         }
@@ -205,7 +203,7 @@ public class DogCollarSlot : DogSlot
         subscribeGiftEvents(dog);
         toggleButtonActive(false);
 
-        //BP Set radialFill to be active and cover button and start lerp from the beginning
+        //BP Activate radial fill image and start lerp coroutine
         radialFill.gameObject.SetActive(true);
         float timeTotal = dog.Info.TotalTimeToReturn;
         float timeRemaining = dog.Info.TimeRemainingScouting;
@@ -238,7 +236,7 @@ public class DogCollarSlot : DogSlot
     void handleGiftFound(CurrencyData gift)
     {
         // BP gift has been found, so deactivate the radial fill image
-        if (radialFill != null)
+        if(radialFill != null)
         {
             radialFill.gameObject.SetActive(false);
         }
@@ -265,12 +263,11 @@ public class DogCollarSlot : DogSlot
 
     void handleDogTimerChange(Dog dog, float timeRemaining)
     {
-        if (timerText && !dog.HasRedeemableGift)
+        if(timerText && !dog.HasRedeemableGift)
         {
             timerText.text = dog.RemainingTimeScoutingStr;
 
-            //BP Instead of doing the below line, start a lerp every second that lerps the radial fill down a second
-            //radialFill.fillAmount = timeRemaining / dog.Info.TotalTimeToReturn;
+            //BP Start a lerp every second that lerps the radial fill down a second
             float totalTime = dog.Info.TotalTimeToReturn;
             StartCoroutine(lerpRadial(timeRemaining, totalTime));
             
@@ -283,13 +280,14 @@ public class DogCollarSlot : DogSlot
     {
         float startPoint = timeRemaining / totalTime;
         float endPoint = (timeRemaining - 1) / totalTime;
-        float t = 0;
+        float lerpTime = 0;
         float currentPoint = startPoint;
+        float lerpLimit = 1;
 
-        while (t < 1)
+        while(lerpTime < lerpLimit)
         {
-            t += Time.deltaTime;
-            currentPoint = Mathf.Lerp(startPoint, endPoint, t);
+            lerpTime += Time.deltaTime;
+            currentPoint = Mathf.Lerp(startPoint, endPoint, lerpTime);
             radialFill.fillAmount = currentPoint;
             yield return new WaitForEndOfFrame();
         }

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -41,13 +41,13 @@ GraphicsSettings:
     type: 0}
   m_TierSettings_Tier1:
     renderingPath: 1
-    useCascadedShadowMaps: 0
+    useCascadedShadowMaps: 1
   m_TierSettings_Tier2:
     renderingPath: 1
-    useCascadedShadowMaps: 0
+    useCascadedShadowMaps: 1
   m_TierSettings_Tier3:
     renderingPath: 1
-    useCascadedShadowMaps: 0
+    useCascadedShadowMaps: 1
   m_DefaultRenderingPath: 1
   m_DefaultMobileRenderingPath: 1
   m_TierSettings: []


### PR DESCRIPTION
I added a radial fill image to the Dog Image prefab, and added a few
lines of code to dogcollarslot.cs. It piggybacks on the existings handle
and init methods. I tagged my work with "BP" out of habit. If this is
too much commenting, let me know. The coroutine lerps the image down
each second for a second.