### PR TITLE
Fixed Timers Freezing When Game Paused

### DIFF
--- a/Assets/Prefabs/PickupPup/Core/GameLogic/Game.prefab
+++ b/Assets/Prefabs/PickupPup/Core/GameLogic/Game.prefab
@@ -87,7 +87,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   preserveOnSceneChange: 1
   resetDataKey: 113
-  saveOnApplicationPause: 0
+  saveOnApplicationPause: 1
   saveOnApplicationQuit: 1
 --- !u!114 &114426272054950630
 MonoBehaviour:


### PR DESCRIPTION
Fixed bug that daily gift and scouting timers would freeze whenever the game was paused so progress was lost.

**Prefabs**
- Game: set saveOnApplicationPause equal to true