### PR TITLE
Temp fix for dog profiles/name tags

### DIFF
--- a/Assets/Scripts/UI/PickupPup/DogWorld/DogWorldSlot.cs
+++ b/Assets/Scripts/UI/PickupPup/DogWorld/DogWorldSlot.cs
@@ -59,6 +59,7 @@ public class DogWorldSlot : DogSlot
 
     public void SubscribeToNameTagClick(PPData.DogAction clickAction)
     {
+        SubscribeToClickWhenOccupied(clickAction);
         if(nameTag)
         {
             nameTag.SubscribeToClick(clickAction);
@@ -67,6 +68,7 @@ public class DogWorldSlot : DogSlot
 
     public void UnsubscribeFromNameTagClick(PPData.DogAction clickAction)
     {
+        UnsubscribeFromClickWhenOccupied(clickAction);
         if(nameTag)
         {
             nameTag.UnsubscribeFromClick(clickAction);


### PR DESCRIPTION
Since the name tags still aren't working, subscription events in dog world slot have been rerouted so that a dog's profile displays when the slot is tapped on.