### PR TITLE
Fixing notifications to only appear once per dog returning from scouting

### DIFF
--- a/Assets/Scripts/Controller/PickupPup/PPGameController.cs
+++ b/Assets/Scripts/Controller/PickupPup/PPGameController.cs
@@ -176,7 +176,6 @@ public class PPGameController : GameController, ICurrencySystem
     #endregion
 
     // The dog the player currently has selected
-    Dog selectedDog;
 	PPTuning tuning;
 	DogDatabase dogDatabase;
     ShopDatabase shop;
@@ -467,11 +466,6 @@ public class PPGameController : GameController, ICurrencySystem
 		}
 	}
         
-	public void SelectDog(Dog dog)
-	{
-		this.selectedDog = dog;
-	}
-
 	public void SendToTargetSlot(Dog dog)
 	{
 		if(HasTargetSlot)
@@ -484,16 +478,6 @@ public class PPGameController : GameController, ICurrencySystem
 	public void ClearTargetSlot()
 	{
 		this.targetSlot = null;
-	}
-
-	public void SendSelectedDogToSlot(DogSlot slot)
-	{
-		sendDogToSlot(this.selectedDog, slot);
-	}
-
-	void sendDogToSlot(Dog dog, DogSlot slot)
-	{
-        slot.Init(dog, inScoutingSelectMode:false);
 	}
 
 	void sendDogToScout(Dog dog) 

--- a/Assets/Scripts/Data/PickupPup/DogDescriptor.cs
+++ b/Assets/Scripts/Data/PickupPup/DogDescriptor.cs
@@ -342,6 +342,12 @@ public class DogDescriptor : PPDescriptor
 			linkedDog.SubscribeToScoutingTimerChange(updateTimeRemainingScouting);
 		}
 		this._scoutingSlotIndex = slotIndex;
+	}
+
+	public void ScheduleScoutingNotification()
+	{
+		// Cleanup in case there was already a notification scheduled
+		cancelScoutingNotification();
 		scoutingNotificationTimeUp = DateTime.Now.AddSeconds(TotalTimeToReturn);
 		NotificationController.Instance.SendNotification(
 			string.Format(k.DOG_SCOUTING_TITLE, Name),
@@ -358,12 +364,9 @@ public class DogDescriptor : PPDescriptor
 		{
 			linkedDog.UnsubscribeFromScoutingTimerChange(updateTimeRemainingScouting);
 		}
-		NotificationController.Instance.CancelNotification(
-			string.Format(k.DOG_SCOUTING_TITLE, Name),
-			string.Format(k.DOG_SCOUTING_MESSAGE, Name),
-			scoutingNotificationTimeUp);
+		cancelScoutingNotification();
 	}
-        
+		        
     public void FindGift(CurrencyData gift)
     {
         this.RedeemableGift = gift;
@@ -433,6 +436,14 @@ public class DogDescriptor : PPDescriptor
 		DogFoodData food = this.eatenFood;
 		this.eatenFood = null;
 		return food;
+	}
+
+	void cancelScoutingNotification()
+	{
+		NotificationController.Instance.CancelNotification(
+			string.Format(k.DOG_SCOUTING_TITLE, Name),
+			string.Format(k.DOG_SCOUTING_MESSAGE, Name),
+			scoutingNotificationTimeUp);
 	}
 
     void callBeginScouting()

--- a/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
+++ b/Assets/Scripts/UI/PickupPup/DogSlot/DogCollarSlot.cs
@@ -91,12 +91,6 @@ public class DogCollarSlot : DogSlot
         }
     }
 
-    public override void Init(Dog dog, bool inScoutingSelectMode)
-    {
-        base.Init(dog, inScoutingSelectMode);
-        initDogScouting(dog, onResume: false);
-    }
-
     protected override void handleChangeDog(Dog previousDog)
     {
         base.handleChangeDog(previousDog);
@@ -129,7 +123,7 @@ public class DogCollarSlot : DogSlot
         dogImage.sprite = dog.Portrait;
         subscribeTimerEvents(dog);
         dog.SetTimer(dogInfo.TimeRemainingScouting);
-		initDogScouting(dog, onResume: true);
+		initDogScouting(dog, onResume:true);
         if(dog.HasRedeemableGift)
         {
             handleGiftFound(dog.PeekAtGift);
@@ -182,6 +176,10 @@ public class DogCollarSlot : DogSlot
     {
         unsubscribeFromDogEvents(dog);
         dog.TrySendToScout();
+		if(!onResume)
+		{
+			dog.ScheduleScoutingNotification();
+		}
         subscribeTimerEvents(dog);
         subscribeGiftEvents(dog);
         toggleButtonActive(false);
@@ -251,9 +249,10 @@ public class DogCollarSlot : DogSlot
         {
             //BP Start a lerp every second that lerps the radial fill down a second
             float totalTime = dog.Info.TotalTimeToReturn;
-            StartCoroutine(lerpRadial(timeRemaining, totalTime));
-            
-
+			if(this)
+			{
+            	StartCoroutine(lerpRadial(timeRemaining, totalTime));
+			}
         }
     }
     

--- a/Assets/Scripts/World/PickupPup/Core/Dog.cs
+++ b/Assets/Scripts/World/PickupPup/Core/Dog.cs
@@ -480,6 +480,11 @@ public class Dog : MobileObjectBehaviour
 		}
 	}
 
+	public void ScheduleScoutingNotification()
+	{
+		descriptor.ScheduleScoutingNotification();
+	}
+
 	public void GiveTimer(PPTimer timer)
 	{
 		this.scoutingTimer = timer;


### PR DESCRIPTION
**Scripts**
- Removed some unnecessary calls from `PPGameController`
- Stopped an init call from occurring twice in `DogCollarSlot`
- Made `ScheduleScoutingNotification` a public method in the `Dog` and `DogDescriptor` classes